### PR TITLE
Use env::var intead of env! in build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,7 @@
 extern crate gazetta;
 
+use std::env;
+
 fn main() {
-    gazetta::cli::gen_completions("gazetta", env!("OUT_DIR"));
+    gazetta::cli::gen_completions("gazetta", &env::var("OUT_DIR").unwrap());
 }


### PR DESCRIPTION
The env! method pulls the variable at *compile time* as opposed to runtime. This
can cause breakage in scenarios with cross compilation, for example. Currently
there's also a pending change to Cargo on the beta release of Rust which breaks
the usage of env! (rust-lang/cargo#3368).

We may roll that change back, but I figured it'd be good to head off future
breakage anyway!